### PR TITLE
デスクトップでサイドバー折りたたみ対応

### DIFF
--- a/app.js
+++ b/app.js
@@ -243,11 +243,17 @@ document.getElementById('search-input').addEventListener('input', e => {
 });
 
 document.getElementById('sidebar-header').addEventListener('click', () => {
-  if (!isMobile()) return;
-  const expanded = document.getElementById('store-panel').classList.toggle('expanded');
-  document.getElementById('sidebar-header').classList.toggle('expanded-arrow', expanded);
-  log.event(`sidebar-header タップ → store-panel ${expanded ? '展開' : '折りたたみ'}`);
-  setTimeout(() => map.invalidateSize(), 320);
+  if (isMobile()) {
+    const expanded = document.getElementById('store-panel').classList.toggle('expanded');
+    document.getElementById('sidebar-header').classList.toggle('expanded-arrow', expanded);
+    log.event(`sidebar-header タップ → store-panel ${expanded ? '展開' : '折りたたみ'}`);
+    setTimeout(() => map.invalidateSize(), 320);
+  } else {
+    const collapsed = document.getElementById('store-panel').classList.toggle('collapsed');
+    document.getElementById('sidebar-header').classList.toggle('panel-collapsed', collapsed);
+    log.event(`sidebar-header クリック → store-panel ${collapsed ? '折りたたみ' : '展開'}`);
+    setTimeout(() => map.invalidateSize(), 320);
+  }
 });
 
 document.getElementById('sidebar-overlay').addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       店舗一覧
       <div class="header-right">
         <span id="sidebar-count"></span>
-        <span id="sidebar-toggle-arrow">▲</span>
+        <svg id="sidebar-toggle-arrow" class="filter-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#aaa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
       </div>
     </div>
 
@@ -76,28 +76,32 @@
           <button id="load-more-button" type="button" hidden>さらに表示</button>
         </div>
       </div>
+    </div>
 
-      <div class="panel-section">
-        <div class="filter-trigger" id="site-trigger-row">
-          <span class="section-title">このHPについて・お問い合わせ</span>
-          <svg class="filter-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#aaa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
-        </div>
-        <div class="filter-expand" id="site-expand">
-          <div class="info-panel-body">
-            <p class="footer-copy">
-              制作者は AutoFor株式会社です。開発や更新の裏側は X と Qiita で発信しています。
-            </p>
-            <p class="footer-disclaimer">
-              このHPに掲載している情報は、AIを用いて作成しています。内容の正確性・最新性・完全性を保証するものではありません。
-            </p>
-            <div class="footer-links">
-              <a href="https://x.com/Kawashima_RPA" target="_blank" rel="noopener">X: @Kawashima_RPA</a>
-              <a href="https://qiita.com/Kawashima_RPA" target="_blank" rel="noopener">Qiita: Kawashima_RPA</a>
-            </div>
-            <p class="modal-company-name">AutoFor株式会社</p>
-            <hr class="info-divider">
-            <button id="contact-modal-open" class="contact-open-button" type="button">お問い合わせはこちら</button>
+    <div class="panel-section">
+      <div class="filter-trigger" id="site-trigger-row">
+        <span class="section-title">このHPについて</span>
+        <svg class="filter-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#aaa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </div>
+      <div class="filter-expand" id="site-expand">
+        <div class="info-panel-body">
+          <p class="footer-copy">
+            制作者は AutoFor株式会社です。開発や更新の裏側は X と Qiita で発信しています。
+          </p>
+          <p class="footer-copy">
+            このHPは、<a href="https://www.city.iizuka.lg.jp/soshiki/70/14632.html" target="_blank" rel="noopener">飯塚市が公開しているPDF</a>を元に作成しました。
+          </p>
+          <p class="footer-disclaimer">
+            このHPに掲載している情報は、AIを用いて作成しています。内容の正確性・最新性・完全性を保証するものではありません。
+          </p>
+          <div class="footer-links">
+            <a href="https://x.com/Kawashima_RPA" target="_blank" rel="noopener">X: @Kawashima_RPA</a>
+            <a href="https://qiita.com/Kawashima_RPA" target="_blank" rel="noopener">Qiita: Kawashima_RPA</a>
+            <a href="https://github.com/AutoFor/iizuka-coupon-map" target="_blank" rel="noopener">GitHub</a>
           </div>
+          <p class="modal-company-name">AutoFor株式会社</p>
+          <hr class="info-divider">
+          <button id="contact-modal-open" class="contact-open-button" type="button">お問い合わせはこちら</button>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -50,10 +50,8 @@ header h1 {
 }
 
 #count-badge {
-  background: rgba(255,255,255,0.25);
-  border-radius: var(--radius-pill);
-  padding: 2px 10px;
   font-size: 13px;
+  opacity: 0.8;
 }
 
 /* ── Filter bar ── */
@@ -102,7 +100,7 @@ header h1 {
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.25s ease;
-  background: var(--surface);
+  background: var(--white);
 }
 .filter-expand.open { max-height: 1200px; }
 
@@ -182,7 +180,7 @@ header h1 {
   padding: 7px 10px;
   font-size: 13px;
   outline: none;
-  background: var(--bg);
+  background: var(--white);
   font-family: inherit;
   color: var(--text);
 }
@@ -205,10 +203,7 @@ header h1 {
 #sidebar-header .header-right { display: flex; align-items: center; gap: 8px; }
 #sidebar-count { color: var(--text-muted); font-weight: 400; font-size: 12px; }
 #sidebar-toggle-arrow {
-  font-size: 11px;
-  color: var(--text-muted);
   transition: transform 0.3s;
-  display: none;
 }
 
 #store-panel {
@@ -245,19 +240,20 @@ header h1 {
 
 #load-more-button {
   width: 100%;
-  border: 1px solid var(--primary-light);
-  border-radius: var(--radius-lg);
-  background: var(--primary-bg);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
   color: var(--primary);
   font: inherit;
   font-size: 13px;
   font-weight: 700;
   padding: 10px 12px;
   cursor: pointer;
+  transition: background 0.15s;
 }
 
 #load-more-button:hover {
-  background: var(--primary-light);
+  background: var(--primary-bg);
 }
 
 .panel-section {
@@ -285,9 +281,9 @@ header h1 {
 .contact-open-button {
   display: inline-flex;
   align-items: center;
-  border: 1px solid var(--primary-light);
-  border-radius: var(--radius-lg);
-  background: var(--primary-bg);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
   color: var(--primary);
   font: inherit;
   font-size: 13px;
@@ -295,10 +291,11 @@ header h1 {
   padding: 10px 14px;
   cursor: pointer;
   justify-self: start;
+  transition: background 0.15s;
 }
 
 .contact-open-button:hover {
-  background: var(--primary-light);
+  background: var(--primary-bg);
 }
 
 .store-item {
@@ -397,34 +394,38 @@ header h1 {
   line-height: 1.7;
   color: var(--text-mid);
 }
+.footer-copy a {
+  color: var(--primary);
+  text-decoration: underline;
+}
 
 .footer-disclaimer {
-  margin-top: 12px;
-  padding: 12px 14px;
-  border-radius: var(--radius-md);
-  background: #fff7e8;
-  border: 1px solid #f3d7a1;
-  font-size: 13px;
+  margin-top: 4px;
+  font-size: 12px;
   line-height: 1.7;
-  color: #8a5a00;
+  color: var(--text-muted);
 }
 
 .footer-links {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+  flex-direction: column;
+  gap: 4px;
   margin-top: 16px;
 }
 
 .footer-links a {
   text-decoration: none;
   color: var(--primary);
-  background: var(--primary-bg);
-  border: 1px solid var(--primary-light);
-  border-radius: var(--radius-pill);
+  background: transparent;
+  border-radius: var(--radius-md);
   padding: 8px 14px;
   font-size: 13px;
   font-weight: 600;
+  transition: background 0.15s;
+}
+
+.footer-links a:hover {
+  background: var(--primary-bg);
 }
 
 .contact-form {
@@ -548,6 +549,20 @@ header h1 {
   cursor: pointer;
 }
 
+/* ── Desktop store-panel collapse ── */
+@media (min-width: 769px) {
+  #store-panel {
+    transition: max-height 0.3s ease, overflow 0.3s;
+    max-height: 10000px;
+  }
+  #store-panel.collapsed {
+    max-height: 0 !important;
+    flex: none !important;
+    overflow: hidden !important;
+  }
+  #sidebar-header.panel-collapsed #sidebar-toggle-arrow { transform: rotate(180deg); }
+}
+
 /* ── Mobile (末尾に置くことでデスクトップルールより優先される) ── */
 @media (max-width: 768px) {
   #main { flex-direction: column; }
@@ -570,7 +585,6 @@ header h1 {
   }
   #side-panel.closed { width: 100%; }
 
-  #sidebar-toggle-arrow { display: inline; }
   #sidebar-header.expanded-arrow #sidebar-toggle-arrow { transform: rotate(180deg); }
 
   #store-panel {


### PR DESCRIPTION
Closes #28


## 変更内容

- デスクトップ表示でサイドバーヘッダークリック時に `store-panel` を折りたたむ/展開するトグル機能を追加
- モバイル・デスクトップで分岐していた `sidebar-header` クリックハンドラーを `if/else` に整理
- `#sidebar-toggle-arrow` を文字（▲）から SVG chevron アイコンに変更し、常時表示に変更
- デスクトップ用 CSS（`#store-panel.collapsed`）を追加し、`max-height` アニメーションで折りたたみを実現
- 「このHPについて」セクションをサイドパネル外に移動し、HTML 構造を整理
- 飯塚市公開 PDF へのリンクと GitHub リンクを情報パネルに追加
- `.footer-disclaimer` のスタイルをシンプル化（警告ボックス → グレーテキスト）
- `.footer-links` を縦並びに変更し、ホバー時に背景色が付くスタイルに統一
- `#load-more-button` と `.contact-open-button` のボーダーを除去してフラットなデザインに変更

## テスト方法

```bash
env TARGET_URL=http://127.0.0.1:8081 npm run dump:localhost
env TARGET_URL=http://127.0.0.1:8081 npm run dump:desktop
env TARGET_URL=http://127.0.0.1:8081 npm run dump:mobile
```

- デスクトップ: サイドバーヘッダークリックで `store-panel` が折りたたまれ、再クリックで展開されること
- デスクトップ: 折りたたみ時に chevron アイコンが 180° 回転すること
- モバイル: 従来どおりスワイプ展開が動作すること
- 「このHPについて」セクションが正しく表示され、飯塚市 PDF リンク・GitHub リンクが機能すること