### PR TITLE
SEO/OGP/JSON-LD メタ情報追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,44 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>令和8年飯塚市生活応援クーポン券マップ</title>
+  <meta name="description" content="令和8年（2026年）飯塚市生活応援クーポン券が使えるお店を地図で検索。グルメ・飲食、小売・買い物、サービスなどカテゴリ別に約640店舗を掲載。デジタル・紙クーポン対応店舗もフィルター可能。">
+  <meta name="keywords" content="飯塚市,生活応援クーポン,クーポン券,令和8年,2026年,飯塚,福岡,クーポンマップ">
+  <link rel="canonical" href="https://www.afr-iizuka-seikatsu-coupon-2026.jp/">
+
+  <!-- OGP -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://www.afr-iizuka-seikatsu-coupon-2026.jp/">
+  <meta property="og:title" content="令和8年飯塚市生活応援クーポン券マップ">
+  <meta property="og:description" content="令和8年（2026年）飯塚市生活応援クーポン券が使えるお店を地図で検索。約640店舗をカテゴリ・券種別に絞り込み可能。">
+  <meta property="og:site_name" content="飯塚市生活応援クーポン券マップ">
+  <meta property="og:locale" content="ja_JP">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="令和8年飯塚市生活応援クーポン券マップ">
+  <meta name="twitter:description" content="令和8年（2026年）飯塚市生活応援クーポン券が使えるお店を地図で検索。約640店舗をカテゴリ・券種別に絞り込み可能。">
+
+  <!-- JSON-LD -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "令和8年飯塚市生活応援クーポン券マップ",
+    "url": "https://www.afr-iizuka-seikatsu-coupon-2026.jp/",
+    "description": "令和8年（2026年）飯塚市生活応援クーポン券が使えるお店を地図で検索できるサービスです。",
+    "applicationCategory": "Map",
+    "inLanguage": "ja",
+    "author": {
+      "@type": "Organization",
+      "name": "AutoFor株式会社",
+      "url": "https://autofor.co.jp/"
+    },
+    "areaServed": {
+      "@type": "City",
+      "name": "飯塚市",
+      "addressCountry": "JP"
+    }
+  }
+  </script>
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">


### PR DESCRIPTION
Closes #32


## 変更内容

- `index.html` に SEO・SNS シェア・構造化データ用のメタ情報を追加
  - `<meta name="description">` / `<meta name="keywords">` / `<link rel="canonical">` を追加
  - OGP タグ（`og:type`, `og:url`, `og:title`, `og:description`, `og:site_name`, `og:locale`）を追加
  - Twitter Card タグ（`twitter:card`, `twitter:title`, `twitter:description`）を追加
  - JSON-LD（`WebApplication` スキーマ）を追加。名称・URL・説明・カテゴリ・言語・著者・対象エリアを記述

## テスト方法

- ブラウザの DevTools で `<head>` 内に各メタタグ・JSON-LD が正しく出力されていることを確認
- [OGP 確認ツール](https://developers.facebook.com/tools/debug/) や [Twitter Card Validator](https://cards-dev.twitter.com/validator) で OGP・Twitter Card が正しくパースされることを確認
- [Google リッチリザルトテスト](https://search.google.com/test/rich-results) で JSON-LD の構造化データが認識されることを確認