### PR TITLE
コンタクトフォームバリデーション改善

### DIFF
--- a/app.js
+++ b/app.js
@@ -402,56 +402,36 @@ document.getElementById('contact-form')?.addEventListener('submit', e => {
   const email = document.getElementById('contact-email')?.value.trim() || '';
   const message = document.getElementById('contact-message')?.value.trim() || '';
   const note = document.getElementById('contact-note');
+  const errorBox = document.getElementById('contact-error');
 
-  if (!applicantType) {
-    note.textContent = 'お問い合わせ種別を選択してください。';
+  // バリデーション：エラーフィールドIDとメッセージのペア
+  const checks = [
+    { id: 'contact-applicant-type', msg: 'お問い合わせ種別を選択してください。', cond: !applicantType },
+    { id: 'contact-category', msg: 'お問い合わせカテゴリを選択してください。', cond: !category },
+    { id: 'contact-company', msg: '御社名を入力してください。', cond: applicantType === 'corporate' && !company },
+    { id: 'contact-store-name', msg: '対象の店舗名を入力してください。', cond: (category === '掲載情報の修正' || category === '掲載削除') && !storeName },
+    { id: 'contact-fix-detail', msg: 'どこを直したいかを入力してください。', cond: category === '掲載情報の修正' && !fixDetail },
+    { id: 'contact-delete-reason', msg: '削除理由を入力してください。', cond: category === '掲載削除' && !deleteReason },
+    { id: 'contact-new-store-name', msg: '新規店舗名を入力してください。', cond: category === '新規掲載' && !newStoreName },
+    { id: 'contact-name', msg: 'お名前を入力してください。', cond: !name },
+    { id: 'contact-email', msg: 'メールアドレスを入力してください。', cond: !email },
+    { id: 'contact-message', msg: 'お問い合わせ内容を入力してください。', cond: !message },
+  ];
+
+  // 赤枠リセット
+  checks.forEach(({ id }) => {
+    document.getElementById(id)?.classList.remove('input-error');
+  });
+
+  const failed = checks.find(c => c.cond);
+  if (failed) {
+    errorBox.textContent = failed.msg;
+    errorBox.hidden = false;
+    document.getElementById(failed.id)?.classList.add('input-error');
+    document.getElementById(failed.id)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     return;
   }
-
-  if (!category) {
-    note.textContent = 'お問い合わせカテゴリを選択してください。';
-    return;
-  }
-
-  if (applicantType === 'corporate' && !company) {
-    note.textContent = '御社名を入力してください。';
-    return;
-  }
-
-  if ((category === '掲載情報の修正' || category === '掲載削除') && !storeName) {
-    note.textContent = '対象の店舗名を入力してください。';
-    return;
-  }
-
-  if (category === '掲載情報の修正' && !fixDetail) {
-    note.textContent = 'どこを直したいかを入力してください。';
-    return;
-  }
-
-  if (category === '掲載削除' && !deleteReason) {
-    note.textContent = '削除理由を入力してください。';
-    return;
-  }
-
-  if (category === '新規掲載' && !newStoreName) {
-    note.textContent = '新規店舗名を入力してください。';
-    return;
-  }
-
-  if (!name) {
-    note.textContent = 'お名前を入力してください。';
-    return;
-  }
-
-  if (!email) {
-    note.textContent = 'メールアドレスを入力してください。';
-    return;
-  }
-
-  if (!message) {
-    note.textContent = 'お問い合わせ内容を入力してください。';
-    return;
-  }
+  errorBox.hidden = true;
 
   note.textContent = '送信中です。しばらくお待ちください。';
   submitButton.disabled = true;

--- a/index.html
+++ b/index.html
@@ -183,10 +183,12 @@
       <h2 id="contact-modal-title">お問い合わせ</h2>
       <button id="contact-modal-close" class="contact-modal-close" type="button" aria-label="閉じる">閉じる</button>
     </div>
-    <p class="footer-copy">
-      内容を入力すると、メールアプリが起動してお問い合わせ用の下書きを作成します。
-    </p>
     <form id="contact-form" class="contact-form">
+      <div class="contact-form-body">
+        <p class="footer-copy">
+          内容を入力して送信してください。通常2営業日以内にご返信します。
+        </p>
+        <p id="contact-error" class="contact-error" hidden></p>
       <label>
         お問い合わせ種別
         <select id="contact-applicant-type" name="applicantType" required>
@@ -252,8 +254,11 @@
         お問い合わせ内容
         <textarea id="contact-message" name="message" rows="5" placeholder="ご相談内容をご記入ください" required></textarea>
       </label>
-      <button type="submit">メールを作成する</button>
-      <p id="contact-note" class="contact-note">送信前にメール本文を確認してください。</p>
+      </div><!-- /.contact-form-body -->
+      <div class="contact-form-footer">
+        <button type="submit">送信する</button>
+        <p id="contact-note" class="contact-note"></p>
+      </div>
     </form>
   </div>
 </section>

--- a/style.css
+++ b/style.css
@@ -454,10 +454,9 @@ header h1 {
   background: var(--primary-bg);
 }
 
-.contact-form {
+.contact-form-body {
   display: grid;
   gap: 12px;
-  margin-top: 16px;
 }
 
 .contact-form label {
@@ -516,6 +515,19 @@ header h1 {
   color: var(--text-muted);
 }
 
+.contact-error {
+  color: #d32f2f;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.contact-form .input-error {
+  border-color: #d32f2f !important;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(211, 47, 47, 0.2);
+}
+
 .modal-company-name {
   margin-top: 18px;
   text-align: center;
@@ -552,12 +564,31 @@ header h1 {
 .contact-modal-card {
   width: min(560px, 100%);
   max-height: min(88dvh, 860px);
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   background: rgba(255,255,255,0.98);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
-  padding: 22px;
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.22);
+  overflow: hidden;
+}
+
+
+.contact-form {
+  display: contents;
+}
+
+.contact-form-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 22px;
+}
+
+.contact-form-footer {
+  flex-shrink: 0;
+  padding: 12px 22px 18px;
+  border-top: 1px solid var(--border);
+  background: rgba(255,255,255,0.98);
 }
 
 .contact-modal-header {
@@ -565,7 +596,8 @@ header h1 {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 14px;
+  padding: 22px 22px 14px;
+  flex-shrink: 0;
 }
 
 .contact-modal-header h2 {


### PR DESCRIPTION
Closes #34


## 変更内容

- バリデーションロジックをデータ駆動型（checks 配列）にリファクタリング（`app.js`）
- エラー時にエラーボックス（`#contact-error`）を表示し、対象フィールドに赤枠（`input-error` クラス）を付与してスクロール
- モーダルのレイアウトを `contact-form-body` / `contact-form-footer` に分割し、フォーム本体をスクロール可能にしつつフッター（送信ボタン）を固定表示（`style.css`, `index.html`）
- 送信ボタンのラベルを「メールを作成する」→「送信する」に変更
- 説明文を「メールアプリが起動して…」→「通常2営業日以内にご返信します。」に更新

## テスト方法

1. ローカルサーバー（`http://127.0.0.1:8081`）を起動
2. 以下のコマンドでスクリーンショット・ログ・DOMを取得し、フォームの表示・動作を確認

```bash
env TARGET_URL=http://127.0.0.1:8081 npm run dump:localhost
env TARGET_URL=http://127.0.0.1:8081 npm run dump:desktop
env TARGET_URL=http://127.0.0.1:8081 npm run dump:mobile
```

3. コンタクトフォームを開き、各必須項目を空のまま送信 → 該当フィールドに赤枠が付き、エラーメッセージが表示されること
4. 必須項目を入力して送信 → エラーが消え「送信中です。」と表示されること
5. モバイル表示でフォームが長い場合、ボディ部分のみスクロールし送信ボタンが常に画面下部に固定されていること