### PR TITLE
Google Analytics計測追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,15 @@
   }
   </script>
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-FF6X5Q94V9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-FF6X5Q94V9');
+  </script>
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">


### PR DESCRIPTION
Closes #40


## 変更内容

- `index.html` に Google Analytics 4（GA4）のトラッキングコード（`G-FF6X5Q94V9`）を追加

## テスト方法

- ページを開き、ブラウザの開発者ツール > Network タブで `gtag/js` リクエストが発火していることを確認
- GA4 管理画面のリアルタイムレポートでアクセスが計測されていることを確認